### PR TITLE
Use JavaConversions.asScalaBuffer rather than JavaConversions.asBuffer.

### DIFF
--- a/app/Global.java
+++ b/app/Global.java
@@ -119,7 +119,7 @@ public class Global extends GlobalSettings
                     ArrayList<Tuple2<String, String>> list = new ArrayList<Tuple2<String, String>>();
                     list.add(ac);
                     scala.collection.immutable.List<Tuple2<String, String>> headers =
-                      JavaConversions.asBuffer( list ).toList();
+                      JavaConversions.asScalaBuffer( list ).toList();
 //
 //
 //            guy -- important.. even though Intellij marks this as error, it is not an error.. ignore it.


### PR DESCRIPTION
asBuffer had been deprecated in scala 2.8.1 which was in 2010. Nowdays, my version of scala doesn't even have this API anymore so it generates an error...
